### PR TITLE
Update README.md for correct jenkins service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Alternatively, you can choose to utilize a separate service account to run the J
    
 The jenkins service account will be created. Now add the *system:deployer* role to this account as show previously for the default service account:
 
-     oc policy add-role-to-user system:deployer system:serviceaccount:jenkins:default 
+     oc policy add-role-to-user system:deployer system:serviceaccount:jenkins:jenkins 
 
 Subsequent sections will illustrate how to leverage this account
 


### PR DESCRIPTION
When using the jenkins service account the add-role-to-user documentation still lists the "default" user when it should list the "jenkins" user.
