### PR TITLE
Small change to jenkins-slave Dockerfile

### DIFF
--- a/jenkins-slave/Dockerfile
+++ b/jenkins-slave/Dockerfile
@@ -18,7 +18,8 @@ RUN yum install -y git tar zip unzip which java-1.8.0-openjdk-devel && \
 COPY jenkins-slave.sh /opt/jenkins-slave/bin/
 
 # Download plugin and modify permissions
-RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
+RUN curl --create-dirs -sSLo
+/opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
   && curl --create-dirs -sSLo /opt/jenkins-slave/bin/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/$JNLP_SLAVE_VERSION/remoting-$JNLP_SLAVE_VERSION.jar \
   && chmod -R 775 /opt/jenkins-slave /var/lib/jenkins && \
   chown -R jenkins-slave:root /opt/jenkins-slave /var/lib/jenkins

--- a/jenkins-slave/Dockerfile
+++ b/jenkins-slave/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y git tar zip unzip which java-1.8.0-openjdk-devel && \
 COPY jenkins-slave.sh /opt/jenkins-slave/bin/
 
 # Download plugin and modify permissions
-RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
+RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION-jar-with-dependencies.jar \
   && curl --create-dirs -sSLo /opt/jenkins-slave/bin/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/$JNLP_SLAVE_VERSION/remoting-$JNLP_SLAVE_VERSION.jar \
   && chmod -R 775 /opt/jenkins-slave /var/lib/jenkins && \
   chown -R jenkins-slave:root /opt/jenkins-slave /var/lib/jenkins


### PR DESCRIPTION
The jenkins-slave Dockerfile was making a curl request to get the swarm client jar, but that file must have been moved because maven.jenkins-ci.org doesn't give a response. I tracked down the file and updated the URL in the curl request. I tried to make it all one commit, but messed up, so just ignore that and the fact that I apparently deleted and put back the last line of the file. Otherwise, I've been following along on your blog post at https://blog.openshift.com/jenkins-slaves-in-openshift-using-an-external-jenkins-environment/ and it's been super helpful!